### PR TITLE
Extra guardrail to prevent returning a nil network object from Test.S…

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,8 @@
 _See [here](./versioning-and-upgrading.md) for information about versioning and upgrading_
 
 # TBD
+### Features
+* Added an extra explanatory error message guardrail if a user's `Test.setup` method accidentally returns a nil `Network` object
 
 # 1.30.0
 ### Fixes

--- a/golang/lib/execution/test_suite_service.go
+++ b/golang/lib/execution/test_suite_service.go
@@ -180,6 +180,9 @@ func (service *TestSuiteService) SetupTest(ctx context.Context, args *bindings.S
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "An error occurred during test setup")
 	}
+	if userNetwork == nil {
+		return nil, stacktrace.NewError("The test setup method returned successfully, but yielded a nil network object - this is a bug with the test's setup method accidentally returning a nil network object")
+	}
 	service.testSetupInfo = &testSetupInfo{
 		network:  userNetwork,
 		testName: testName,


### PR DESCRIPTION
…etup

